### PR TITLE
feat: added health check endpoint to prevent idling

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ for (const path of paths) {
 
 // This route is used by an external cron job to keep the server instance alive on hosting platforms like Render
 // Free tier may goes to sleep after 15 min of inactivity
-
 server.get("/proxy-status", async (request, reply) => {
   return { status: "ok", service: "supabase-proxy" };
 });

--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ for (const path of paths) {
   });
 }
 
+// This route is used by an external cron job to keep the server instance alive on hosting platforms like Render
+// Free tier may goes to sleep after 15 min of inactivity
+
+server.get("/proxy-status", async (request, reply) => {
+  return { status: "ok", service: "supabase-proxy" };
+});
+
 // PORT will be provided by render
 server
   .listen({ port: process.env.PORT || 3000, host: "0.0.0.0" })


### PR DESCRIPTION
Adds a new `GET /proxy-status `route to serve as a health check

This endpoint can be periodically pinged by a cron job to generate activity, preventing the service from sleeping on hosting platforms with inactivity policies